### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/lib/humanfilesize.ts
+++ b/lib/humanfilesize.ts
@@ -19,8 +19,8 @@ export function formatFileSize(size: number, skipSmallSizes: boolean = false): s
 	}
 	if (order < 2) {
 		relativeSize = parseFloat(relativeSize).toFixed(0);
-	} else if (relativeSize.substr(relativeSize.length - 2, 2) === '.0') {
-		relativeSize = relativeSize.substr(0, relativeSize.length - 2);
+	} else if (relativeSize.slice(-2) === '.0') {
+		relativeSize = relativeSize.slice(0, -2);
 	} else {
 		relativeSize = parseFloat(relativeSize).toLocaleString(getCanonicalLocale());
 	}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.