### PR TITLE
Cleanup, remove unnecessary check and move to 100% coverage

### DIFF
--- a/__tests__/humanFileSize.spec.ts
+++ b/__tests__/humanFileSize.spec.ts
@@ -19,7 +19,8 @@ describe('humanFileSize', () => {
                 [128000, '125 KB'],
                 [128000000, '122.1 MB'],
                 [128000000000, '119.2 GB'],
-                [128000000000000, '116.4 TB']
+                [128000000000000, '116.4 TB'],
+                [128000000000000.0, '116.4 TB'],
             ]
             for (var i = 0; i < data.length; i++) {
                 expect(formatFileSize(data[i][0])).toEqual(data[i][1])
@@ -33,7 +34,8 @@ describe('humanFileSize', () => {
                 [128000, '125 KB'],
                 [128000000, '122.1 MB'],
                 [128000000000, '119.2 GB'],
-                [128000000000000, '116.4 TB']
+                [128000000000000, '116.4 TB'],
+                [128000000000000.0, '116.4 TB'],
             ]
             for (var i = 0; i < data.length; i++) {
                 expect(formatFileSize(data[i][0], true)).toEqual(data[i][1])
@@ -50,7 +52,8 @@ describe('humanFileSize', () => {
                 [128000, '125 KB'],
                 [128000000, '122,1 MB'],
                 [128000000000, '119,2 GB'],
-                [128000000000000, '116,4 TB']
+                [128000000000000, '116,4 TB'],
+                [128000000000000.0, '116,4 TB'],
             ]
             for (var i = 0; i < data.length; i++) {
                 expect(formatFileSize(data[i][0])).toEqual(data[i][1])

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,0 +1,72 @@
+import {
+	formatFileSize,
+	addNewFileMenuEntry,
+	removeNewFileMenuEntry,
+	getNewFileMenuEntries,
+} from '../lib/index'
+import { Entry, NewFileMenu } from '../lib/newFileMenu';
+
+declare global {
+	interface Window {
+		OC: any;
+		_nc_newfilemenu: NewFileMenu;
+	}
+}
+
+describe('Exports checks', () => {
+	test('formatFileSize', () => {
+		expect(formatFileSize).toBeTruthy()
+		expect(typeof formatFileSize).toBe('function')
+	})
+
+	test('addNewFileMenuEntry', () => {
+		expect(addNewFileMenuEntry).toBeTruthy()
+		expect(typeof addNewFileMenuEntry).toBe('function')
+	})
+
+	test('removeNewFileMenuEntry', () => {
+		expect(removeNewFileMenuEntry).toBeTruthy()
+		expect(typeof removeNewFileMenuEntry).toBe('function')
+	})
+
+	test('getNewFileMenuEntries', () => {
+		expect(getNewFileMenuEntries).toBeTruthy()
+		expect(typeof getNewFileMenuEntries).toBe('function')
+	})
+})
+
+
+describe('NewFileMenu methods', () => {
+	const entry = {
+		id: 'empty-file',
+		displayName: 'Create empty file',
+		templateName: 'New file.txt',
+		iconClass: 'icon-filetype-text',
+		handler: () => {}
+	} as Entry
+
+	test('Init NewFileMenu', () => {
+		expect(window._nc_newfilemenu).toBeUndefined()
+
+		const menuEntries = getNewFileMenuEntries()
+		expect(menuEntries).toHaveLength(0)
+
+		expect(window._nc_newfilemenu).toBeDefined()
+		expect(window._nc_newfilemenu).toBeInstanceOf(NewFileMenu)
+	})
+
+	test('Use existing initialized NewFileMenu', () => {
+		expect(window._nc_newfilemenu).toBeDefined()
+		expect(window._nc_newfilemenu).toBeInstanceOf(NewFileMenu)
+
+		addNewFileMenuEntry(entry)
+
+		expect(window._nc_newfilemenu).toBeDefined()
+		expect(window._nc_newfilemenu).toBeInstanceOf(NewFileMenu)
+
+		removeNewFileMenuEntry(entry)
+
+		expect(window._nc_newfilemenu).toBeDefined()
+		expect(window._nc_newfilemenu).toBeInstanceOf(NewFileMenu)
+	})
+})

--- a/__tests__/newFileMenu.spec.ts
+++ b/__tests__/newFileMenu.spec.ts
@@ -113,13 +113,53 @@ describe('NewFileMenu addEntry', () => {
 
 		expect(() => {
 			newFileMenu.registerEntry({
+				id: 123456,
+				displayName: '123456',
+				templateName: 'New file.txt',
+				iconClass: 'icon-filetype-text',
+				handler: () => {}
+			} as unknown as Entry)
+		}).toThrowError('Invalid entry property')
+
+		expect(() => {
+			newFileMenu.registerEntry({
 				id: 'empty-file',
 				displayName: 123456,
 				templateName: 'New file.txt',
 				iconClass: 'icon-filetype-text',
 				handler: () => {}
 			} as unknown as Entry)
-		}).toThrowError('Invalid entry')
+		}).toThrowError('Invalid entry property')
+
+		expect(() => {
+			newFileMenu.registerEntry({
+				id: 'empty-file',
+				displayName: '123456',
+				templateName: 123465,
+				iconClass: 'icon-filetype-text',
+				handler: () => {}
+			} as unknown as Entry)
+		}).toThrowError('Invalid entry property')
+
+		expect(() => {
+			newFileMenu.registerEntry({
+				id: 'empty-file',
+				displayName: '123456',
+				templateName: 'New file.txt',
+				iconClass: 123456,
+				handler: () => {}
+			} as unknown as Entry)
+		}).toThrowError('Invalid entry property')
+
+		expect(() => {
+			newFileMenu.registerEntry({
+				id: 'empty-file',
+				displayName: '123456',
+				templateName: 'New file.txt',
+				iconSvgInline: 123456,
+				handler: () => {}
+			} as unknown as Entry)
+		}).toThrowError('Invalid entry property')
 
 		expect(() => {
 			newFileMenu.registerEntry({
@@ -127,7 +167,7 @@ describe('NewFileMenu addEntry', () => {
 				displayName: '123456',
 				templateName: 'New file.txt',
 				iconClass: 'icon-filetype-text',
-				if: false,
+				if: true,
 				handler: () => {}
 			} as unknown as Entry)
 		}).toThrowError('Invalid entry, if must be a valid function')

--- a/lib/humanfilesize.ts
+++ b/lib/humanfilesize.ts
@@ -43,19 +43,20 @@ export function formatFileSize(size: number|string, skipSmallSizes: boolean = fa
 	order = Math.min(humanList.length - 1, order);
 	const readableFormat = humanList[order];
 	let relativeSize = (size / Math.pow(1024, order)).toFixed(1);
+
 	if (skipSmallSizes === true && order === 0) {
-		if (relativeSize !== "0.0") {
+		if (relativeSize !== '0.0') {
 			return '< 1 KB';
 		} else {
 			return '0 KB';
 		}
 	}
+
 	if (order < 2) {
 		relativeSize = parseFloat(relativeSize).toFixed(0);
-	} else if (relativeSize.slice(-2) === '.0') {
-		relativeSize = relativeSize.slice(0, -2);
 	} else {
 		relativeSize = parseFloat(relativeSize).toLocaleString(getCanonicalLocale());
 	}
+
 	return relativeSize + ' ' + readableFormat;
 }

--- a/lib/newFileMenu.ts
+++ b/lib/newFileMenu.ts
@@ -90,7 +90,7 @@ export class NewFileMenu {
 			|| typeof entry.templateName !== 'string'
 			|| (entry.iconClass && typeof entry.iconClass !== 'string')
 			|| (entry.iconSvgInline && typeof entry.iconSvgInline !== 'string')) {
-			throw new Error('Invalid entry')
+			throw new Error('Invalid entry property')
 		}
 
 		if (entry.if !== undefined && typeof entry.if !== 'function') {


### PR DESCRIPTION
- `parseFloat` always strip the `.0` from the number, we don't need a dedicated check for it. I added some tests for it to make sure we don't have a regression: 100% coverage now
- 100% coverage on the `newFileMenu` too