### PR TITLE
feat(FileAction): add file action support

### DIFF
--- a/__tests__/fileAction.spec.ts
+++ b/__tests__/fileAction.spec.ts
@@ -1,0 +1,212 @@
+import { getFileActions, registerFileAction, FileAction } from '../lib/fileAction'
+import logger from '../lib/utils/logger';
+
+declare global {
+	interface Window {
+		OC: any;
+		_nc_fileactions: FileAction[] | undefined;
+	}
+}
+
+describe('FileActions init', () => {
+
+	beforeEach(() => {
+		delete window._nc_fileactions
+	})
+
+	test('Getting empty uninitialized FileActions', () => {
+		logger.debug = jest.fn()
+		const fileActions = getFileActions()
+		expect(window._nc_fileactions).toBeUndefined()
+		expect(fileActions).toHaveLength(0)
+		expect(logger.debug).toHaveBeenCalledTimes(0)
+	})
+
+	test('Initializing FileActions', () => {
+		logger.debug = jest.fn()
+		const action = new FileAction({
+			id: 'test',
+			displayName: () => 'Test',
+			iconSvgInline: () => '<svg></svg>',
+			exec: async () => true,
+		})
+
+		expect(action.id).toBe('test')
+		expect(action.displayName([], {})).toBe('Test')
+		expect(action.iconSvgInline([], {})).toBe('<svg></svg>')
+
+		registerFileAction(action)
+
+		expect(window._nc_fileactions).toHaveLength(1)
+		expect(getFileActions()).toHaveLength(1)
+		expect(getFileActions()[0]).toStrictEqual(action)
+		expect(logger.debug).toHaveBeenCalled()
+	})
+
+	test('Duplicate FileAction gets rejected', () => {
+		logger.error = jest.fn()
+		const action = new FileAction({
+			id: 'test',
+			displayName: () => 'Test',
+			iconSvgInline: () => '<svg></svg>',
+			exec: async () => true,
+		})
+
+		registerFileAction(action)
+		expect(getFileActions()).toHaveLength(1)
+		expect(getFileActions()[0]).toStrictEqual(action)
+
+		const action2 = new FileAction({
+			id: 'test',
+			displayName: () => 'Test 2',
+			iconSvgInline: () => '<svg></svg>',
+			exec: async () => true,
+		})
+
+		registerFileAction(action2)
+		expect(getFileActions()).toHaveLength(1)
+		expect(getFileActions()[0]).toStrictEqual(action)
+		expect(logger.error).toHaveBeenCalledWith('FileAction test already registered', { action: action2 })
+	})
+})
+
+describe('Invalid FileAction creation', () => {
+	test('Invalid id', () => {
+		expect(() => {
+			new FileAction({
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+			} as any as FileAction)
+		}).toThrowError('Invalid id')
+	})
+	test('Invalid displayName', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+			} as any as FileAction)
+		}).toThrowError('Invalid displayName function')
+	})
+	test('Invalid iconSvgInline', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: '<svg></svg>',
+				exec: async () => true,
+			} as any as FileAction)
+		}).toThrowError('Invalid iconSvgInline function')
+	})
+	test('Invalid exec', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: false,
+			} as any as FileAction)
+		}).toThrowError('Invalid exec function')
+	})
+	test('Invalid enabled', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				enabled: false,
+			} as any as FileAction)
+		}).toThrowError('Invalid enabled function')
+	})
+	test('Invalid execBatch', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				execBatch: false,
+			} as any as FileAction)
+		}).toThrowError('Invalid execBatch function')
+	})
+	test('Invalid order', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				order: 'invalid',
+			} as any as FileAction)
+		}).toThrowError('Invalid order')
+	})
+	test('Invalid default', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				default: 'invalid',
+			} as any as FileAction)
+		}).toThrowError('Invalid default')
+	})
+	test('Invalid inline', () => {
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				inline: true,
+			} as any as FileAction)
+		}).toThrowError('Invalid inline function')
+
+		expect(() => {
+			new FileAction({
+				id: 'test',
+				displayName: () => 'Test',
+				iconSvgInline: () => '<svg></svg>',
+				exec: async () => true,
+				inline: () => true,
+				renderInline: false
+			} as any as FileAction)
+		}).toThrowError('Invalid renderInline function')
+	})
+})
+
+describe('FileActions creation', () => {
+	test('create valid FileAction', async () => {
+		logger.debug = jest.fn()
+		const action = new FileAction({
+			id: 'test',
+			displayName: () => 'Test',
+			iconSvgInline: () => '<svg></svg>',
+			exec: async () => true,
+			execBatch: async () => [true],
+			enabled: () => true,
+			order: 100,
+			default: true,
+			inline: () => true,
+			renderInline() {
+				const span = document.createElement('span')
+				span.textContent = 'test'
+				return span
+			},
+		})
+
+		expect(action.id).toBe('test')
+		expect(action.displayName([], {})).toBe('Test')
+		expect(action.iconSvgInline([], {})).toBe('<svg></svg>')
+		await expect(action.exec({} as any, {})).resolves.toBe(true)
+		await expect(action.execBatch?.([], {})).resolves.toStrictEqual([true])
+		expect(action.enabled?.({} as any, {})).toBe(true)
+		expect(action.order).toBe(100)
+		expect(action.default).toBe(true)
+		expect(action.inline?.({} as any, {})).toBe(true)
+		expect(action.renderInline?.({} as any, {}).outerHTML).toBe('<span>test</span>')
+	})
+})

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -29,6 +29,29 @@ describe('Node testing', () => {
 	})
 })
 
+describe('FileId attribute', () => {
+	test('FileId null fallback', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma'
+		})
+		expect(file.fileid).toBeUndefined()
+	})
+
+	test('FileId source ending slash', () => {
+		const file = new Folder({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				fileid: 1234
+			}
+		})
+		expect(file.fileid).toBe(1234)
+	})
+})
+
 describe('Sanity checks', () => {
 	test('Invalid id', () => {
 		expect(() => new File({

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -15,13 +15,13 @@ import { File as FileSource } from '../lib/files/file'
 import { Folder as FolderSource } from '../lib/files/folder'
 import { Permission as PermissionSource } from '../lib/permissions'
 import { FileType as FileTypeSource } from '../lib/files/fileType'
-
 import { Entry, NewFileMenu } from '../lib/newFileMenu';
+import { FileAction, registerFileAction, getFileActions } from '../lib/fileAction'
 
 declare global {
 	interface Window {
 		OC: any;
-		_nc_newfilemenu: NewFileMenu;
+		_nc_newfilemenu: NewFileMenu | undefined;
 	}
 }
 
@@ -73,6 +73,21 @@ describe('Exports checks', () => {
 
 	test('Node', () => {
 		expect(Node).toBeTruthy()
+		expect(typeof Node).toBe('function')
+	})
+
+	test('FileAction', () => {
+		expect(FileAction).toBeTruthy()
+		expect(typeof FileAction).toBe('function')
+	})
+
+	test('registerFileAction', () => {
+		expect(registerFileAction).toBeTruthy()
+		expect(typeof Node).toBe('function')
+	})
+
+	test('getFileActions', () => {
+		expect(getFileActions).toBeTruthy()
 		expect(typeof Node).toBe('function')
 	})
 })

--- a/__tests__/newFileMenu.spec.ts
+++ b/__tests__/newFileMenu.spec.ts
@@ -4,7 +4,7 @@ import logger from '../lib/utils/logger';
 declare global {
 	interface Window {
 		OC: any;
-		_nc_newfilemenu: NewFileMenu;
+		_nc_newfilemenu: NewFileMenu | undefined;
 	}
 }
 

--- a/lib/fileAction.ts
+++ b/lib/fileAction.ts
@@ -1,0 +1,171 @@
+/**
+ * @copyright Copyright (c) 2021 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { Node } from "./files/node"
+import logger from "./utils/logger"
+
+interface FileActionData {
+	/** Unique ID */
+	id: string
+	/** Translatable string displayed in the menu */
+	displayName: (files: Node[], view) => string
+	/** Svg as inline string. <svg><path fill="..." /></svg> */
+	iconSvgInline: (files: Node[], view) => string
+	/** Condition wether this action is shown or not */
+	enabled?: (files: Node[], view) => boolean
+	/**
+	 * Function executed on single file action
+	 * @returns true if the action was executed, false otherwise
+	 * @throws Error if the action failed
+	 */
+	exec: (file: Node, view) => Promise<boolean>,
+	/**
+	 * Function executed on multiple files action
+	 * @returns true if the action was executed, false otherwise
+	 * @throws Error if the action failed
+	 */
+	execBatch?: (files: Node[], view) => Promise<boolean[]>
+	/** This action order in the list */
+	order?: number,
+	/** Make this action the default */
+	default?: boolean,
+	/**
+	 * If true, the renderInline function will be called
+	 */
+	inline?: (file: Node, view) => boolean,
+	/**
+	 * If defined, the returned html element will be
+	 * appended before the actions menu.
+	 */
+	renderInline?: (file: Node, view) => HTMLElement,
+}
+
+export class FileAction {
+	private _action: FileActionData
+	
+	constructor(action: FileActionData) {
+		this.validateAction(action)
+		this._action = action
+	}
+
+	get id() {
+		return this._action.id
+	}
+
+	get displayName() {
+		return this._action.displayName
+	}
+
+	get iconSvgInline() {
+		return this._action.iconSvgInline
+	}
+
+	get enabled() {
+		return this._action.enabled
+	}
+
+	get exec() {
+		return this._action.exec
+	}
+
+	get execBatch() {
+		return this._action.execBatch
+	}
+
+	get order() {
+		return this._action.order
+	}
+
+	get default() {
+		return this._action.default
+	}
+
+	get inline() {
+		return this._action.inline
+	}
+
+	get renderInline() {
+		return this._action.renderInline
+	}
+
+	private validateAction(action: FileActionData) {
+		if (!action.id || typeof action.id !== 'string') {
+			throw new Error('Invalid id')
+		}
+
+		if (!action.displayName || typeof action.displayName !== 'function') {
+			throw new Error('Invalid displayName function')
+		}
+
+		if (!action.iconSvgInline || typeof action.iconSvgInline !== 'function') {
+			throw new Error('Invalid iconSvgInline function')
+		}
+
+		if (!action.exec || typeof action.exec !== 'function') {
+			throw new Error('Invalid exec function')
+		}
+
+		// Optional properties --------------------------------------------
+		if ('enabled' in action && typeof action.enabled !== 'function') {
+			throw new Error('Invalid enabled function')
+		}
+
+		if ('execBatch' in action && typeof action.execBatch !== 'function') {
+			throw new Error('Invalid execBatch function')
+		}
+
+		if ('order' in action && typeof action.order !== 'number') {
+			throw new Error('Invalid order')
+		}
+
+		if ('default' in action && typeof action.default !== 'boolean') {
+			throw new Error('Invalid default')
+		}
+
+		if ('inline' in action && typeof action.inline !== 'function') {
+			throw new Error('Invalid inline function')
+		}
+
+		if ('renderInline' in action && typeof action.renderInline !== 'function') {
+			throw new Error('Invalid renderInline function')
+		}
+	}
+}
+
+export const registerFileAction = function(action: FileAction): void {
+	if (typeof window._nc_fileactions === 'undefined') {
+		window._nc_fileactions = []
+		logger.debug('FileActions initialized')
+	}
+
+	// Check duplicates
+	if (window._nc_fileactions.find(search => search.id === action.id)) {
+		logger.error(`FileAction ${action.id} already registered`, { action })
+		return
+	}
+
+	window._nc_fileactions.push(action)
+}
+
+export const getFileActions = function(): FileAction[] {
+	return window._nc_fileactions || []
+}

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -157,6 +157,13 @@ export abstract class Node {
 	}
 
 	/**
+	 * Get the file id if defined in attributes
+	 */
+	get fileid(): number|undefined {
+		return this.attributes?.fileid
+	}
+
+	/**
 	 * Move the node to a new destination
 	 *
 	 * @param {string} destination the new source.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,6 +23,7 @@
 
 export { formatFileSize } from './humanfilesize'
 export { type Entry } from './newFileMenu'
+import { FileAction } from './fileAction'
 import { type Entry, getNewFileMenu, NewFileMenu } from './newFileMenu'
 
 export { FileType } from './files/fileType'
@@ -30,11 +31,13 @@ export { File } from './files/file'
 export { Folder } from './files/folder'
 export { Node } from './files/node'
 export { Permission, parseWebdavPermissions } from './permissions'
+export { FileAction, registerFileAction, getFileActions } from './fileAction'
 
 declare global {
 	interface Window {
 		OC: any;
-		_nc_newfilemenu: NewFileMenu;
+		_nc_newfilemenu: NewFileMenu | undefined;
+		_nc_fileactions: FileAction[] | undefined;
 	}
 }
 


### PR DESCRIPTION
RFC: https://github.com/nextcloud/server/issues/21835

``` ts
interface FileActionData {
	id: string
	displayName: (files: Node[], view) => string
	iconSvgInline: (files: Node[], view) => string
	enabled?: (files: Node[], view) => boolean
	exec: (file: Node, view) => Promise<boolean>,
	execBatch?: (files: Node[], view) => Promise<boolean[]>
	order?: number,
	default?: boolean,
	inline?: (file: Node, view) => boolean,
	renderInline?: (file: Node, view) => HTMLElement,
}
```