### PR TITLE
fix: do not update mtime if not already defined

### DIFF
--- a/__tests__/files/file.spec.ts
+++ b/__tests__/files/file.spec.ts
@@ -223,4 +223,21 @@ describe('Altering attributes updates mtime', () => {
 		expect(file.mtime?.getDate()).toBe(new Date().getDate())
 		expect(file.attributes.test).toBeUndefined()
 	})
+
+	test('mtime is NOT updated if not initially defined', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				test: true,
+			},
+		})
+		expect(file.attributes.test).toBe(true)
+		delete file.attributes.test
+
+		// Check that mtime has been updated
+		expect(file.mtime).toBeUndefined()
+		expect(file.attributes.test).toBeUndefined()
+	})
 })

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -40,13 +40,13 @@ export abstract class Node {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			set: (target: Attribute, prop: string, value: any): any => {
 				// Edit modification time
-				this._data.mtime = new Date()
+				this.updateMtime()
 				// Apply original changes
 				return Reflect.set(target, prop, value)
 			},
 			deleteProperty: (target: Attribute, prop: string) => {
 				// Edit modification time
-				this._data.mtime = new Date()
+				this.updateMtime()
 				// Apply original changes
 				return Reflect.deleteProperty(target, prop)
 			},
@@ -222,7 +222,7 @@ export abstract class Node {
 	move(destination: string) {
 		validateData({ ...this._data, source: destination }, this._knownDavService)
 		this._data.source = destination
-		this._data.mtime = new Date()
+		this.updateMtime()
 	}
 
 	/**
@@ -236,6 +236,15 @@ export abstract class Node {
 			throw new Error('Invalid basename')
 		}
 		this.move(dirname(this.source) + '/' + basename)
+	}
+
+	/**
+	 * Update the mtime if exists.
+	 */
+	private updateMtime() {
+		if (this._data.mtime) {
+			this._data.mtime = new Date()
+		}
 	}
 
 }


### PR DESCRIPTION
Context:
1. In the files app, have a list of node with unknown mtime
2. the mtime column is hidden 
3. have an action updating a Node attribute
4. the mtime column suddenly appear because at least one node now have a valid mtime

Correct behaviour:
- the mtime column stays hidden and the mtime stays undefined