### PR TITLE
fix: use Node and not string for the new file menu handler arg

### DIFF
--- a/lib/newFileMenu.ts
+++ b/lib/newFileMenu.ts
@@ -48,9 +48,9 @@ export interface Entry {
 	/**
 	 * Function to be run after creation
 	 * @param {Folder} context the creation context. Usually the current folder
-	 * @param {string[]} fileList list of file names present in the destination folder
+	 * @param {Node[]} content list of file/folders present in the context folder
 	 */
-	handler: (context: Folder, fileList: string[]) => void
+	handler: (context: Folder, content: Node[]) => void
 }
 
 export class NewFileMenu {


### PR DESCRIPTION
How else are we gonna get the mtime or size.... :see_no_evil: 

![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/970a207c-66fd-4ec3-9d09-83872e6abec7)
