### PR TITLE
fix(node): replacing attributes does not update mtime and clean leftovers props

### DIFF
--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -599,4 +599,48 @@ describe('Attributes update', () => {
 		expect(file.attributes?.owner).toBe('emma')
 	})
 
+	test('Updating attributes does NOT update mtime', () => {
+		const mtime = new Date()
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				etag: '1234',
+			},
+			mtime,
+		})
+
+		expect(file.mtime?.toISOString()).toBe(mtime?.toISOString())
+
+		// Update attributes
+		file.update({
+			etag: '5678',
+		})
+
+		// Mtime is not updated
+		expect(file.mtime?.toISOString()).toBe(mtime?.toISOString())
+	})
+
+	test('Updating attributes removes the leftover ones', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				etag: '1234',
+			},
+		})
+
+		expect(file.attributes?.etag).toBe('1234')
+
+		// Update attributes
+		file.update({
+			displayName: 'Picture.jpg',
+		})
+
+		// The leftover attribute is removed
+		expect(file.attributes?.etag).toBeUndefined()
+		expect(file.attributes?.displayName).toBe('Picture.jpg')
+	})
 })

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -350,11 +350,15 @@ export abstract class Node {
 	}
 
 	/**
-	 * Update the attributes of the node
+	 * Replace the attributes of the node.
+	 * This will also remove any attributes not provided in the new attributes.
 	 *
 	 * @param attributes The new attributes to update on the Node attributes
 	 */
 	update(attributes: Attribute) {
+		const mtime = this._data.mtime
+
+		// Update the incoming attributes
 		for (const [name, value] of Object.entries(attributes)) {
 			try {
 				if (value === undefined) {
@@ -371,6 +375,16 @@ export abstract class Node {
 				throw e
 			}
 		}
+
+		// Delete the leftover attributes
+		for (const name of Object.keys(this.attributes)) {
+			if (!(name in attributes)) {
+				delete this.attributes[name]
+			}
+		}
+
+		// Restore the mtime
+		this._data.mtime = mtime
 	}
 
 }


### PR DESCRIPTION
Regression between https://github.com/nextcloud-libraries/nextcloud-files/pull/947 and https://github.com/nextcloud-libraries/nextcloud-files/pull/967

### Note

There is a reason `update` replaces all attributes and delete old ones.
Update is mostly here to be used on events, when you want to update the node entirely with freshly updated data. It's not made to update a subset of attributes in bulk.