### PR TITLE
fix: Make types of File and Folder more explicit

### DIFF
--- a/lib/files/file.ts
+++ b/lib/files/file.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { FileType } from './fileType'
-import { type INode, Node } from './node'
+import { Node } from './node'
 
 export class File extends Node {
 
-	get type(): FileType {
+	get type(): FileType.File {
 		return FileType.File
 	}
 
@@ -23,6 +23,4 @@ export class File extends Node {
 /**
  * Interface of the File class
  */
-export interface IFile extends INode {
-	readonly type: FileType.File
-}
+export type IFile = Pick<File, keyof File>

--- a/lib/files/folder.ts
+++ b/lib/files/folder.ts
@@ -2,9 +2,9 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import type { NodeData } from './nodeData'
 import { FileType } from './fileType'
-import { type INode, Node } from './node'
-import { type NodeData } from './nodeData'
+import { Node } from './node'
 
 export class Folder extends Node {
 
@@ -16,22 +16,22 @@ export class Folder extends Node {
 		})
 	}
 
-	get type(): FileType {
+	get type(): FileType.Folder {
 		return FileType.Folder
 	}
 
-	get extension(): string|null {
+	get extension(): null {
 		return null
 	}
 
-	get mime(): string {
+	get mime(): 'httpd/unix-directory' {
 		return 'httpd/unix-directory'
 	}
 
 	/**
 	 * Returns a clone of the folder
 	 */
-	clone(): Node {
+	clone(): Folder {
 		return new Folder(this.data)
 	}
 
@@ -40,8 +40,4 @@ export class Folder extends Node {
 /**
  * Interface of the folder class
  */
-export interface IFolder extends INode {
-	readonly type: FileType.Folder
-	readonly extension: null
-	readonly mime: 'httpd/unix-directory'
-}
+export type IFolder = Pick<Folder, keyof Folder>


### PR DESCRIPTION
Both inherit from Node which is generic, thus e.g. the `mime` field is of type `string`. But for folders the mime can never be something different to `'httpd/unix-directory'`.
So the correct type would be the string literal `'httpd/unix-directory'`.

The same for the `type` attribute for `File` and `Folder`.

---
:arrow_up: While this could be seen as an improvement it actually fixes a Typescript issue:
```ts
const IFolder = new Folder({ ... })
```

This I expect to work, but it fails with:
> Type 'Folder' is not assignable to type 'IFolder'.
>  Types of property 'type' are incompatible.
>    Type 'FileType' is not assignable to type 'FileType.Folder'.
