### PR TITLE
feat(actions): standardize contexts

### DIFF
--- a/__tests__/actions/fileAction.spec.ts
+++ b/__tests__/actions/fileAction.spec.ts
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { Node } from '../../lib/node/index.ts'
+import type { Folder, Node } from '../../lib/node/index.ts'
 import type { View } from '../../lib/navigation/view.ts'
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { getFileActions, registerFileAction, FileAction, DefaultType, FileActionData } from '../../lib/actions/index.ts'
 import logger from '../../lib/utils/logger.ts'
 
+const folder = {} as Folder
+const view = {} as View
 describe('FileActions init', () => {
 
 	beforeEach(() => {
@@ -34,8 +36,8 @@ describe('FileActions init', () => {
 		})
 
 		expect(action.id).toBe('test')
-		expect(action.displayName([], {} as unknown as View)).toBe('Test')
-		expect(action.iconSvgInline([], {} as unknown as View)).toBe('<svg></svg>')
+		expect(action.displayName({ view, folder, nodes: [], content: [] })).toBe('Test')
+		expect(action.iconSvgInline({ view, folder, nodes: [], content: [] })).toBe('<svg></svg>')
 
 		registerFileAction(action)
 
@@ -244,18 +246,20 @@ describe('FileActions creation', () => {
 			},
 		})
 
+		const node = {} as Node
+
 		expect(action.id).toBe('test')
-		expect(action.displayName([], {} as unknown as View)).toBe('Test')
-		expect(action.title?.([], {} as unknown as View)).toBe('Test title')
-		expect(action.iconSvgInline([], {} as unknown as View)).toBe('<svg></svg>')
-		await expect(action.exec({} as unknown as Node, {} as unknown as View, '/')).resolves.toBe(true)
-		await expect(action.execBatch?.([], {} as unknown as View, '/')).resolves.toStrictEqual([true])
-		expect(action.enabled?.([], {} as unknown as View)).toBe(true)
+		expect(action.displayName({ view, folder, nodes: [], content: [] })).toBe('Test')
+		expect(action.title?.({ view, folder, nodes: [], content: [] })).toBe('Test title')
+		expect(action.iconSvgInline({ view, folder, nodes: [], content: [] })).toBe('<svg></svg>')
+		await expect(action.exec({ view, folder, nodes: [node], content: [] })).resolves.toBe(true)
+		await expect(action.execBatch?.({ view, folder, nodes: [], content: [] })).resolves.toStrictEqual([true])
+		expect(action.enabled?.({ view, folder, nodes: [], content: [] })).toBe(true)
 		expect(action.order).toBe(100)
 		expect(action.parent).toBe('123')
 		expect(action.destructive).toBe(true)
 		expect(action.default).toBe(DefaultType.DEFAULT)
-		expect(action.inline?.({} as unknown as Node, {} as unknown as View)).toBe(true)
-		expect((await action.renderInline?.({} as unknown as Node, {} as unknown as View))?.outerHTML).toBe('<span>test</span>')
+		expect(action.inline?.({ view, folder, nodes: [], content: [] })).toBe(true)
+		expect((await action.renderInline?.({ view, folder, nodes: [], content: [] }))?.outerHTML).toBe('<span>test</span>')
 	})
 })

--- a/__tests__/actions/fileListAction.spec.ts
+++ b/__tests__/actions/fileListAction.spec.ts
@@ -10,6 +10,9 @@ import { getFileListActions, registerFileListAction, FileListAction } from '../.
 import { Folder } from '../../lib/node/index.ts'
 import logger from '../../lib/utils/logger.ts'
 
+const folder = {} as Folder
+const view = {} as View
+
 const mockAction = (id: string) => new FileListAction({
 	id,
 	displayName: () => 'Test',
@@ -37,8 +40,8 @@ describe('FileListActions init', () => {
 		const testAction = mockAction('test')
 
 		expect(testAction.id).toBe('test')
-		expect(testAction.displayName({} as unknown as View)).toBe('Test')
-		expect(testAction.iconSvgInline!({} as unknown as View)).toBe('<svg></svg>')
+		expect(testAction.displayName({ view, folder })).toBe('Test')
+		expect(testAction.iconSvgInline!({ view, folder })).toBe('<svg></svg>')
 
 		registerFileListAction(testAction)
 		expect(actions).toHaveLength(1)
@@ -155,10 +158,10 @@ describe('FileListAction creation', () => {
 		})
 
 		expect(testAction.id).toBe('test')
-		expect(testAction.displayName({} as unknown as View)).toBe('Test')
-		expect(testAction.iconSvgInline!({} as unknown as View)).toBe('<svg></svg>')
+		expect(testAction.displayName({ view, folder })).toBe('Test')
+		expect(testAction.iconSvgInline!({ view, folder })).toBe('<svg></svg>')
 		expect(testAction.order).toBe(0)
-		expect(testAction.enabled?.({} as unknown as View, [], {} as Folder)).toBe(true)
-		await expect(testAction.exec({} as unknown as View, [], {} as Folder)).resolves.toBe(undefined)
+		expect(testAction.enabled?.({ view, folder })).toBe(true)
+		await expect(testAction.exec({ view, folder, nodes: [], content: [] })).resolves.toBe(undefined)
 	})
 })

--- a/lib/actions/fileAction.ts
+++ b/lib/actions/fileAction.ts
@@ -2,9 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-import type { Node } from '../node/node.ts'
-import type { View } from '../navigation/view.ts'
+import type { ActionContext, ActionContextSingle } from '../types'
 
 import logger from '../utils/logger.ts'
 
@@ -48,13 +46,13 @@ export interface FileActionData {
 	/** Unique ID */
 	id: string
 	/** Translatable string displayed in the menu */
-	displayName: (files: Node[], view: View) => string
+	displayName: (context: ActionContext) => string
 	/** Translatable title for of the action */
-	title?: (files: Node[], view: View) => string
+	title?: (context: ActionContext) => string
 	/** Svg as inline string. <svg><path fill="..." /></svg> */
-	iconSvgInline: (files: Node[], view: View) => string
+	iconSvgInline: (context: ActionContext) => string
 	/** Condition wether this action is shown or not */
-	enabled?: (files: Node[], view: View) => boolean
+	enabled?: (context: ActionContext) => boolean
 
 	/**
 	 * Function executed on single file action
@@ -62,14 +60,14 @@ export interface FileActionData {
 	 * false otherwise and null if the action is silent/undefined.
 	 * @throws Error if the action failed
 	 */
-	exec: (file: Node, view: View, dir: string) => Promise<boolean|null>,
+	exec: (context: ActionContextSingle) => Promise<boolean|null>,
 	/**
 	 * Function executed on multiple files action
 	 * @return true if the action was executed successfully,
 	 * false otherwise and null if the action is silent/undefined.
 	 * @throws Error if the action failed
 	 */
-	execBatch?: (files: Node[], view: View, dir: string) => Promise<(boolean|null)[]>
+	execBatch?: (context: ActionContext) => Promise<(boolean|null)[]>
 
 	/** This action order in the list */
 	order?: number
@@ -104,12 +102,12 @@ export interface FileActionData {
 	/**
 	 * If true, the renderInline function will be called
 	 */
-	inline?: (file: Node, view: View) => boolean,
+	inline?: (context: ActionContext) => boolean,
 	/**
 	 * If defined, the returned html element will be
 	 * appended before the actions menu.
 	 */
-	renderInline?: (file: Node, view: View) => Promise<HTMLElement | null>,
+	renderInline?: (context: ActionContext) => Promise<HTMLElement | null>,
 }
 
 export class FileAction {

--- a/lib/actions/fileListAction.ts
+++ b/lib/actions/fileListAction.ts
@@ -2,10 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-import type { Folder } from '../node/folder.ts'
-import type { Node } from '../node/node.ts'
-import type { View } from '../navigation/view.ts'
+import type { ActionContext, ViewActionContext } from '../types'
 
 import logger from '../utils/logger.ts'
 
@@ -14,21 +11,18 @@ interface FileListActionData {
 	id: string
 
 	/** Translated name of the action */
-	displayName: (view: View) => string
+	displayName: (context: ViewActionContext) => string
 
 	/** Raw svg string */
-	iconSvgInline?: (view: View) => string
+	iconSvgInline?: (context: ViewActionContext) => string
 
 	/** Sort order */
 	order: number
 
 	/**
 	 * Condition whether this action is shown or not
-	 * @param view The current view
-	 * @param nodes The nodes in the current directory
-	 * @param folder The current folder
 	 */
-	enabled?: (view: View, nodes: Node[], folder: Folder) => boolean
+	enabled?: (context: ViewActionContext) => boolean
 
 	/**
 	 * Function executed on single file action
@@ -36,7 +30,7 @@ interface FileListActionData {
 	 * false otherwise and null if the action is silent/undefined.
 	 * @throws Error if the action failed
 	 */
-	exec: (view: View, nodes: Node[], folder: Folder) => Promise<boolean|null>,
+	exec: (context: ActionContext) => Promise<boolean|null>,
 }
 
 export class FileListAction {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Folder, Node } from './node/index.ts'
+import { View } from './navigation/index.ts'
+
+type ActionContextSingle = {
+	nodes: [Node],
+	view: View,
+	folder: Folder,
+	content: Node[],
+}
+
+type ActionContext = {
+	nodes: Node[],
+	view: View,
+	folder: Folder,
+	content: Node[],
+}
+
+type ViewActionContext = {
+	view: View,
+	folder: Folder,
+}


### PR DESCRIPTION
Following discussion on https://github.com/nextcloud-libraries/nextcloud-files/pull/1113

This would be a breaking change unless we add a conversion layer to support the old legacy way.
BUT, the cleanest way, imho, is to quickly update server and communicate to devs asap


```ts
// Before
action.exec(node, view, '/path/to/node')

// After
action.exec({
	nodes: [node],
	view: View,
	folder: Folder,
	content: Node[],
})
```