### PR TITLE
feat(recent-search): add nc:upload_time as a select prop

### DIFF
--- a/lib/dav/davProperties.ts
+++ b/lib/dav/davProperties.ts
@@ -151,6 +151,7 @@ export function getRecentSearch(timestamp: number): string {
 		<d:select>
 			<d:prop>
 				${getDavProperties()}
+				${supportsUploadTime ? '<nc:upload_time/>' : ''}
 			</d:prop>
 		</d:select>
 		<d:from>

--- a/lib/dav/davProperties.ts
+++ b/lib/dav/davProperties.ts
@@ -29,6 +29,7 @@ export const defaultDavProperties = [
 	'oc:owner-id',
 	'oc:permissions',
 	'oc:size',
+	'nc:upload_time',
 ]
 
 export const defaultDavNamespaces = {
@@ -151,7 +152,6 @@ export function getRecentSearch(timestamp: number): string {
 		<d:select>
 			<d:prop>
 				${getDavProperties()}
-				${supportsUploadTime ? '<nc:upload_time/>' : ''}
 			</d:prop>
 		</d:select>
 		<d:from>


### PR DESCRIPTION
* Resolves: #

## Summary

* Related to https://github.com/nextcloud/server/pull/58908
- Adds support for `<nc:upload_time/>` on defaultDavProperties.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
