### PR TITLE
fix(upload): expose the current uploader statistics

### DIFF
--- a/__tests__/uploader/upload.e2e.spec.ts
+++ b/__tests__/uploader/upload.e2e.spec.ts
@@ -159,6 +159,61 @@ describe('Uploader (current API)', () => {
 		expect(events).toContain('finished')
 	})
 
+	it('should expose upload statistics', async () => {
+		const client = getClient()
+		await client.deleteFile('/files/admin/test-stats').catch(() => {})
+		await client.createDirectory('/files/admin/test-stats')
+
+		const folder = new Folder({
+			owner: 'admin',
+			root: '/files/admin',
+			source: `${defaultRemoteURL}/files/admin/test-stats`,
+		})
+		const uploader = new Uploader(false, folder)
+
+		// Before any upload the statistics are at their defaults
+		expect(uploader.statistics).toEqual({
+			eta: Infinity,
+			progress: 0,
+			speed: -1,
+			speedReadable: '',
+		})
+
+		// Capture the progress reported by the statistics while uploading
+		const observedProgress: number[] = []
+		uploader.addEventListener('uploadProgress', () => {
+			observedProgress.push(uploader.statistics.progress)
+		})
+
+		// Upload a 9 MiB file: large enough that the request body is streamed in several
+		// progress events, but below the default 10 MiB chunk size so it stays a single
+		// upload with monotonically increasing progress. This lets us assert that the
+		// statistics are updated *during* the upload, not only once it has finished.
+		const content = 'x'.repeat(9 * 1024 * 1024)
+		const finishedPromise = new Promise<void>((resolve) => uploader.addEventListener('finished', () => resolve()))
+		const upload = await uploader.upload('large.txt', new File([content], 'large.txt', { type: 'text/plain' }))
+		await finishedPromise
+
+		expect(upload.status).toBe(UploadStatus.FINISHED)
+
+		// The statistics were updated several times while uploading …
+		expect(observedProgress.length).toBeGreaterThan(1)
+		// … with at least one intermediate value reported during (not only at the end of) the upload …
+		expect(observedProgress.some((progress) => progress > 0 && progress < 100)).toBe(true)
+		// … and finally reached completion.
+		expect(Math.max(...observedProgress)).toBe(100)
+
+		// Once all uploads are finished the uploader resets its statistics back to the defaults
+		expect(uploader.statistics).toEqual({
+			eta: Infinity,
+			progress: 0,
+			speed: -1,
+			speedReadable: '',
+		})
+
+		await expect(client.getFileContents('/files/admin/test-stats/large.txt', { format: 'text' })).resolves.toBe(content)
+	})
+
 	it('should cancel a queued upload', async () => {
 		const client = getClient()
 		await client.deleteFile('/files/admin/test-cancel').catch(() => {})

--- a/lib/upload/uploader/Uploader.spec.ts
+++ b/lib/upload/uploader/Uploader.spec.ts
@@ -188,4 +188,67 @@ describe('Uploader (current API)', () => {
 		expect(Array.isArray(uploads)).toBe(true)
 		expect(uploads.length).toBeGreaterThanOrEqual(1)
 	})
+
+	describe('statistics', () => {
+		it('exposes default statistics before any upload', () => {
+			const uploader = new Uploader()
+			expect(uploader.statistics).toEqual({
+				eta: Infinity,
+				progress: 0,
+				speed: -1,
+				speedReadable: '',
+			})
+		})
+
+		it('reflects the upload progress in the statistics', async () => {
+			const uploader = new Uploader()
+			// 'hello' has a size of 5 bytes, the mock reports half (2.5) before finishing
+			const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+
+			const observedProgress: number[] = []
+			uploader.addEventListener('uploadProgress', () => {
+				observedProgress.push(uploader.statistics.progress)
+			})
+
+			await uploader.upload('/hello.txt', file)
+
+			// the mock emits progress at half (2.5 / 5 = 50%) and once more when finished (100%)
+			expect(observedProgress).toContain(50)
+			expect(observedProgress).toContain(100)
+		})
+
+		it('resets the statistics once all uploads are finished', async () => {
+			const uploader = new Uploader()
+			const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+
+			await uploader.upload('/hello.txt', file)
+
+			// #onFinished resets the uploader (and its ETA) on the next tick
+			await vi.waitFor(() => {
+				expect(uploader.statistics).toEqual({
+					eta: Infinity,
+					progress: 0,
+					speed: -1,
+					speedReadable: '',
+				})
+			})
+		})
+
+		it('does not track statistics for uploads queued while paused', async () => {
+			const uploader = new Uploader()
+			const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+
+			await uploader.pause()
+
+			const observedProgress: number[] = []
+			uploader.addEventListener('uploadProgress', () => {
+				observedProgress.push(uploader.statistics.progress)
+			})
+
+			await uploader.upload('/hello.txt', file)
+
+			// while paused the ETA stays idle, so no progress is accumulated
+			expect(observedProgress.every((progress) => progress === 0)).toBe(true)
+		})
+	})
 })

--- a/lib/upload/uploader/Uploader.ts
+++ b/lib/upload/uploader/Uploader.ts
@@ -29,6 +29,25 @@ export const UploaderStatus = Object.freeze({
 
 type TUploaderStatus = typeof UploaderStatus[keyof typeof UploaderStatus]
 
+export interface IUploaderStatistics {
+	/**
+	 * Estimated time in seconds. If the time is not yet estimated, it will return `Infinity`.
+	 */
+	eta: number
+	/**
+	 * The progress in percentage (0-100) done.
+	 */
+	progress: number
+	/**
+	 * Transfer speed in bytes per second. Returns `-1` if not yet estimated.
+	 */
+	speed: number
+	/**
+	 * Get the speed in human readable format using file sizes like 10KB/s. Returns the empty string if not yet estimated.
+	 */
+	speedReadable: string
+}
+
 interface BaseOptions {
 	/**
 	 * Abort signal to cancel the upload
@@ -193,6 +212,18 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	 */
 	public get queue(): IUpload[] {
 		return [...this.#uploadQueue]
+	}
+
+	/**
+	 * Get current statistics of the uploader.
+	 */
+	public get statistics(): IUploaderStatistics {
+		return {
+			eta: this.#eta.time,
+			progress: this.#eta.progress,
+			speed: this.#eta.speed,
+			speedReadable: this.#eta.speedReadable,
+		}
 	}
 
 	/**

--- a/lib/upload/uploader/Uploader.ts
+++ b/lib/upload/uploader/Uploader.ts
@@ -233,6 +233,7 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	 */
 	public async pause() {
 		this.#jobQueue.pause()
+		this.#eta.pause()
 		this.#status = UploaderStatus.PAUSED
 		await this.#jobQueue.onPendingZero()
 		this.dispatchTypedEvent('paused', new CustomEvent('paused'))
@@ -244,6 +245,7 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	 */
 	public start() {
 		this.#jobQueue.start()
+		this.#eta.resume()
 		this.#status = UploaderStatus.UPLOADING
 		this.dispatchTypedEvent('resumed', new CustomEvent('resumed'))
 		logger.debug('Uploader resumed')
@@ -321,6 +323,7 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 			this.#attachEventListeners(upload)
 		}
 		this.#uploadQueue.push(...uploads)
+		this.#startTracking()
 		this.dispatchTypedEvent('uploadStarted', new CustomEvent('uploadStarted', { detail: upload }))
 		await upload.start(this.#jobQueue)
 		return uploads
@@ -343,9 +346,21 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 
 		this.#attachEventListeners(upload)
 		this.#uploadQueue.push(upload)
+		this.#startTracking()
 		this.dispatchTypedEvent('uploadStarted', new CustomEvent('uploadStarted', { detail: upload }))
 		await upload.start(this.#jobQueue)
 		return upload
+	}
+
+	/**
+	 * Start the statistics tracking for a newly queued upload.
+	 * The ETA is only resumed when the uploader is not paused,
+	 * so that uploads added while paused do not skew the speed estimation.
+	 */
+	#startTracking() {
+		if (this.#status !== UploaderStatus.PAUSED) {
+			this.#eta.resume()
+		}
 	}
 
 	/**

--- a/lib/upload/uploader/index.ts
+++ b/lib/upload/uploader/index.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export type { Eta } from './Eta.ts'
 export type { IUpload } from './Upload.ts'
+export type { IUploaderStatistics } from './Uploader.ts'
 
-export { EtaStatus } from './Eta.ts'
 export { UploadStatus } from './Upload.ts'
 export { Uploader, UploaderStatus } from './Uploader.ts'


### PR DESCRIPTION
Allows to access the statistics of the the uploader

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
