### PR TITLE
fix(upload): only create directory if needed

### DIFF
--- a/lib/upload/uploader/UploadFileTree.ts
+++ b/lib/upload/uploader/UploadFileTree.ts
@@ -134,7 +134,10 @@ export class UploadFileTree extends Upload implements IUpload {
 		this.uploadedBytes = 0
 
 		this.status = UploadStatus.UPLOADING
-		await this.#createDirectory(queue)
+		// if this is not the root of a tree, we need to create the directory first before uploading the children
+		if (this.#directory.webkitRelativePath) {
+			await this.#createDirectory(queue)
+		}
 		if (this.needConflictResolution && this.#conflictsCallback) {
 			const nodes = await this.#conflictsCallback(
 				this.#directory.children.map((node) => basename(node.name)),


### PR DESCRIPTION
When doing a batch upload / file tree upload, we should not try to create the root folder which is the empty string.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
