### PR TITLE
refactor(upload): remove duplicated uploader status information

### DIFF
--- a/lib/upload/uploader/Uploader.spec.ts
+++ b/lib/upload/uploader/Uploader.spec.ts
@@ -5,6 +5,7 @@
 
 import type { IUpload, TUploadStatus } from './Upload.ts'
 
+import PQueue from 'p-queue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Folder } from '../../node/folder.ts'
 import { UploadStatus } from './Upload.ts'
@@ -149,13 +150,63 @@ describe('Uploader (current API)', () => {
 		await paused
 
 		uploader.start()
-		expect(uploader.status).toBe(UploaderStatus.UPLOADING)
+		// The status is derived from the job queue: with no queued/running jobs
+		// a started (not paused) uploader is IDLE, not UPLOADING.
+		expect(uploader.status).toBe(UploaderStatus.IDLE)
 		await resumed
 
 		// reset should clear queue and set IDLE
 		uploader.reset()
 		expect(uploader.status).toBe(UploaderStatus.IDLE)
 		expect(uploader.queue).toEqual([])
+	})
+
+	it('returns to IDLE when reset while paused', async () => {
+		const uploader = new Uploader()
+
+		await uploader.pause()
+		expect(uploader.status).toBe(UploaderStatus.PAUSED)
+
+		// resetting must un-pause so the uploader is usable again afterwards
+		uploader.reset()
+		expect(uploader.status).toBe(UploaderStatus.IDLE)
+	})
+
+	describe('status (derived from the job queue)', () => {
+		// The status getter is pure logic over the underlying p-queue state,
+		// so we drive it by stubbing the queue's getters.
+		const stubQueue = (state: { isPaused: boolean, pending: number, size: number }) => {
+			vi.spyOn(PQueue.prototype, 'isPaused', 'get').mockReturnValue(state.isPaused)
+			vi.spyOn(PQueue.prototype, 'pending', 'get').mockReturnValue(state.pending)
+			vi.spyOn(PQueue.prototype, 'size', 'get').mockReturnValue(state.size)
+		}
+
+		it('is IDLE when the queue is running but empty', () => {
+			stubQueue({ isPaused: false, pending: 0, size: 0 })
+			expect(new Uploader().status).toBe(UploaderStatus.IDLE)
+		})
+
+		it('is PAUSED when the queue is paused', () => {
+			// Paused takes precedence even if jobs are still in flight
+			stubQueue({ isPaused: true, pending: 2, size: 3 })
+			expect(new Uploader().status).toBe(UploaderStatus.PAUSED)
+		})
+
+		it('is UPLOADING when a single upload is in flight (nothing queued behind it)', () => {
+			// Regression guard: a lone running job has pending === 1, size === 0
+			stubQueue({ isPaused: false, pending: 1, size: 0 })
+			expect(new Uploader().status).toBe(UploaderStatus.UPLOADING)
+		})
+
+		it('is UPLOADING when uploads are queued behind running ones', () => {
+			stubQueue({ isPaused: false, pending: 5, size: 3 })
+			expect(new Uploader().status).toBe(UploaderStatus.UPLOADING)
+		})
+
+		it('is UPLOADING when uploads are only waiting in the queue', () => {
+			stubQueue({ isPaused: false, pending: 0, size: 4 })
+			expect(new Uploader().status).toBe(UploaderStatus.UPLOADING)
+		})
 	})
 
 	it('uploads a file and emits progress and finished events', async () => {

--- a/lib/upload/uploader/Uploader.ts
+++ b/lib/upload/uploader/Uploader.ts
@@ -110,7 +110,6 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	#eta = new Eta()
 	#destinationFolder: IFolder
 	#customHeaders: Map<string, string> = new Map()
-	#status: TUploaderStatus = UploaderStatus.IDLE
 	#uploadQueue: IUpload[] = []
 	#jobQueue: PQueue = new PQueue({
 		concurrency: getMaxParallelUploads(),
@@ -159,7 +158,13 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	}
 
 	public get status(): TUploaderStatus {
-		return this.#status
+		if (this.#jobQueue.isPaused) {
+			return UploaderStatus.PAUSED
+		}
+		if (this.#jobQueue.pending > 0 || this.#jobQueue.size > 0) {
+			return UploaderStatus.UPLOADING
+		}
+		return UploaderStatus.IDLE
 	}
 
 	/**
@@ -234,7 +239,6 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	public async pause() {
 		this.#jobQueue.pause()
 		this.#eta.pause()
-		this.#status = UploaderStatus.PAUSED
 		await this.#jobQueue.onPendingZero()
 		this.dispatchTypedEvent('paused', new CustomEvent('paused'))
 		logger.debug('Uploader paused')
@@ -246,7 +250,6 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	public start() {
 		this.#jobQueue.start()
 		this.#eta.resume()
-		this.#status = UploaderStatus.UPLOADING
 		this.dispatchTypedEvent('resumed', new CustomEvent('resumed'))
 		logger.debug('Uploader resumed')
 	}
@@ -260,8 +263,11 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 
 		this.#uploadQueue = []
 		this.#jobQueue.clear()
+		// Resume the (now empty) job queue so a reset always returns to the IDLE
+		// state — otherwise a reset while paused would leave the uploader stuck
+		// reporting PAUSED and block any subsequent upload.
+		this.#jobQueue.start()
 		this.#eta.reset()
-		this.#status = UploaderStatus.IDLE
 		this.dispatchTypedEvent('reset', new CustomEvent('reset'))
 		logger.debug('Uploader reset')
 	}
@@ -358,7 +364,7 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 	 * so that uploads added while paused do not skew the speed estimation.
 	 */
 	#startTracking() {
-		if (this.#status !== UploaderStatus.PAUSED) {
+		if (this.status !== UploaderStatus.PAUSED) {
 			this.#eta.resume()
 		}
 	}


### PR DESCRIPTION
Its already provided by the job queue, so no need to duplicate state handling in the uploader.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
