### PR TITLE
fix(uploader): the conflicts callback needs to get the relative path

### DIFF
--- a/lib/upload/uploader/Uploader.spec.ts
+++ b/lib/upload/uploader/Uploader.spec.ts
@@ -71,6 +71,12 @@ vi.mock('./UploadFile.ts', () => ({
 	},
 }))
 
+// Capture the arguments the Uploader passes to UploadFileTree so we can assert
+// on the (wrapped) conflicts callback.
+const uploadFileTreeMock = vi.hoisted(() => ({
+	instances: [] as Array<{ destination: string, options: Record<string, any> }>,
+}))
+
 vi.mock('./UploadFileTree.ts', () => ({
 	UploadFileTree: class implements IUpload {
 		source = 'file:///test'
@@ -82,7 +88,10 @@ vi.mock('./UploadFileTree.ts', () => ({
 		signal = new AbortController().signal
 		children: IUpload[] = []
 		private listeners: Record<string, ((ev?: CustomEvent) => void)[]> = {}
-		constructor() {}
+		constructor(destination: string, _directory: unknown, options: Record<string, any> = {}) {
+			uploadFileTreeMock.instances.push({ destination, options })
+		}
+
 		addEventListener = ((ev: string, cb: (ev?: CustomEvent) => void) => {
 			this.listeners[ev] = this.listeners[ev] || []
 			this.listeners[ev].push(cb)
@@ -107,6 +116,7 @@ vi.mock('./UploadFileTree.ts', () => ({
 describe('Uploader (current API)', () => {
 	beforeEach(() => {
 		authMock.getCurrentUser.mockReturnValue({ uid: 'tester' })
+		uploadFileTreeMock.instances.length = 0
 	})
 
 	afterEach(() => {
@@ -187,6 +197,55 @@ describe('Uploader (current API)', () => {
 		const uploads = await uploader.batchUpload('/dir', [new File(['a'], 'a.txt')])
 		expect(Array.isArray(uploads)).toBe(true)
 		expect(uploads.length).toBeGreaterThanOrEqual(1)
+	})
+
+	describe('batchUpload conflicts callback', () => {
+		// destination folder source is mocked to https://localhost/remote.php/dav/files/test
+		const target = 'https://localhost/remote.php/dav/files/test/dir'
+
+		/** Run a batchUpload with the given callback and return the callback handed to UploadFileTree */
+		const getWrappedCallback = async (callback?: unknown) => {
+			uploadFileTreeMock.instances.length = 0
+			const uploader = new Uploader()
+			await uploader.batchUpload('/dir', [new File(['a'], 'a.txt')], callback ? { callback } as any : undefined)
+			expect(uploadFileTreeMock.instances).toHaveLength(1)
+			expect(uploadFileTreeMock.instances[0].destination).toBe(target)
+			return uploadFileTreeMock.instances[0].options.callback as
+				| ((nodes: string[], path: string) => Promise<unknown>)
+				| undefined
+		}
+
+		it('passes no callback to UploadFileTree when none was given', async () => {
+			const wrapped = await getWrappedCallback()
+			expect(wrapped).toBeFalsy()
+		})
+
+		it('wraps the callback so it receives a clean relative path', async () => {
+			const userCallback = vi.fn(async () => ({}))
+			const wrapped = await getWrappedCallback(userCallback)
+			expect(wrapped).toBeTypeOf('function')
+
+			// the root of the batch upload maps to an empty relative path
+			await wrapped!(['file.txt'], target)
+			expect(userCallback).toHaveBeenLastCalledWith(['file.txt'], '')
+
+			// nested folder: the absolute upload prefix is stripped, no leading slash
+			await wrapped!(['file.txt'], `${target}/sub`)
+			expect(userCallback).toHaveBeenLastCalledWith(['file.txt'], 'sub')
+
+			// deeper nesting keeps the inner separators
+			await wrapped!(['file.txt'], `${target}/sub/deep`)
+			expect(userCallback).toHaveBeenLastCalledWith(['file.txt'], 'sub/deep')
+		})
+
+		it('forwards the callback result (rename map / false) unchanged', async () => {
+			const renameMap = { 'a.txt': 'b.txt' }
+			const wrapped = await getWrappedCallback(vi.fn(async () => renameMap))
+			await expect(wrapped!(['a.txt'], target)).resolves.toBe(renameMap)
+
+			const wrappedCancel = await getWrappedCallback(vi.fn(async () => false))
+			await expect(wrappedCancel!(['a.txt'], target)).resolves.toBe(false)
+		})
 	})
 
 	describe('statistics', () => {

--- a/lib/upload/uploader/Uploader.ts
+++ b/lib/upload/uploader/Uploader.ts
@@ -309,10 +309,16 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 		// create a meta upload to ensure all ongoing child requests are listed
 		const target = `${this.destination.source.replace(/\/$/, '')}/${destination.replace(/^\//, '')}`
 		const headers = Object.fromEntries(this.#customHeaders.entries())
+		const _callback = options?.callback
+		// The callback is adjusted to be called with the path relative to the upload target
+		// instead of the full absolute URL.
+		// We decode the path segments and strip a leading slash so the callback receives a
+		// clean relative path (e.g. '' for the target root, 'sub/deep' for a nested folder).
+		const callback = _callback && ((nodes: string[], path: string) => _callback(nodes, path.substring(target.length).replace(/^\//, '')))
 		const upload = new UploadFileTree(
 			target,
 			rootFolder,
-			{ ...options, headers },
+			{ ...options, callback, headers },
 		)
 		if (options?.signal) {
 			options.signal.addEventListener('abort', upload.cancel)


### PR DESCRIPTION
Previously only the relative path was passed, this is also more helpful when working with the uploader.
As most API we provide does not work with fully URLs but with paths relative to a root.

So this adds a wrapper around the user provided callback to reduce the path argument to a relative path.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
